### PR TITLE
Support static linkage to libcriu.a

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -1,5 +1,9 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
+
+  # If you want to link libcriu.a statically to your app, uncomment
+  # conf.cc.defines << "MRB_CRIU_USE_STATIC"
+
   conf.gembox 'default'
   conf.gem '../mruby-criu'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,8 +9,11 @@ require_relative 'tasks/staticify'
 MRuby::Gem::Specification.new('mruby-criu') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
-  # spec.linker.libraries << 'criu'
 
-  spec.extend CRIU::Staticify
-  spec.bundle_libcriu
+  if spec.build.cc.defines.flatten.include?("MRB_CRIU_USE_STATIC")
+    spec.extend CRIU::Staticify
+    spec.bundle_libcriu
+  else
+    spec.linker.libraries << 'criu'
+  end
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,5 +1,16 @@
+module CRIU
+  unless CRIU.const_defined? :CRIU_VERSION
+    CRIU_VERSION = "3.10"
+  end
+end
+
+require_relative 'tasks/staticify'
+
 MRuby::Gem::Specification.new('mruby-criu') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
-  spec.linker.libraries << 'criu'
+  # spec.linker.libraries << 'criu'
+
+  spec.extend CRIU::Staticify
+  spec.bundle_libcriu
 end

--- a/tasks/criu_a.patch
+++ b/tasks/criu_a.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/Makefile b/lib/Makefile
+index 9463284..1facc25 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -1,4 +1,5 @@
+ CRIU_SO			:= libcriu.so
++CRIU_A			:= libcriu.a
+ UAPI_HEADERS		:= lib/c/criu.h images/rpc.proto
+ 
+ #
+@@ -19,6 +20,9 @@ ldflags-so		+= -lprotobuf-c
+ lib/c/$(CRIU_SO): lib/c/built-in.o
+ 	$(call msg-link, $@)
+ 	$(Q) $(CC) -shared $(cflags-so) -o $@ $^ $(ldflags-so) $(LDFLAGS)
++lib/c/$(CRIU_A): lib/c/built-in.o
++	$(call msg-link, $@)
++	ar rcs $@ $^
+ lib-c: lib/c/$(CRIU_SO)
+ .PHONY: lib-c
+ 

--- a/tasks/staticify.rb
+++ b/tasks/staticify.rb
@@ -1,0 +1,58 @@
+require 'fileutils'
+require 'open3'
+
+module CRIU::Staticify
+  PATCH_PATH = File.expand_path(File.dirname(__FILE__) + '/criu_a.patch')
+
+  def run_command env, command
+    STDOUT.sync = true
+    puts "EXEC\t[mruby-criu] #{command}"
+    Open3.popen2e(env, command) do |stdin, stdout, thread|
+      print stdout.read
+      fail "#{command} failed" if thread.value != 0
+    end
+  end
+
+  def bundle_libcriu
+    version = CRIU::CRIU_VERSION
+    tarball_url = "https://github.com/checkpoint-restore/criu/archive/v#{version}.tar.gz"
+
+    def criu_dir(b); "#{b.build_dir}/vendor/libcriu"; end
+    def libcriu_dir(b); "#{criu_dir(b)}/lib/c"; end
+    def libcriu_header(b); "#{criu_dir(b)}/lib/c/criu.h"; end
+    def libcriu_a(b); libfile "#{criu_dir(b)}/lib/c/libcriu"; end
+
+    task :clean do
+      FileUtils.rm_rf [libcriu_dir(build)]
+    end
+
+    file libcriu_header(build) do
+      unless File.exist? libcriu_dir(build)
+        tmpdir = '/tmp'
+        run_command ENV, "rm -rf #{tmpdir}/libcriu-#{version}"
+        run_command ENV, "mkdir -p #{File.dirname(criu_dir(build))}"
+        run_command ENV, "curl -sL #{tarball_url} | tar -xz -f - -C #{tmpdir}"
+        run_command ENV, "mv -f #{tmpdir}/criu-#{version} #{criu_dir(build)}"
+        run_command ENV, "cd #{criu_dir(build)} && patch -p1 < #{PATCH_PATH}"
+      end
+    end
+
+    file libcriu_a(build) => libcriu_header(build) do
+      unless File.exist?(libcriu_a(build))
+        Dir.chdir criu_dir(build) do
+          ENV["LD_FLAGS"] = "-lprotobuf-c"
+           run_command ENV, "make lib/c/libcriu.a"
+        end
+      end
+    end
+
+    libmruby_a = libfile("#{build.build_dir}/lib/libmruby")
+    file libmruby_a => libcriu_a(build)
+
+    self.cc.include_paths << File.dirname(libcriu_header(build))
+    self.linker.library_paths << File.dirname(libcriu_a(build))
+    # NOTE: order is important!!
+    self.linker.libraries << 'criu'
+    self.linker.libraries << 'protobuf-c'
+  end
+end

--- a/tasks/staticify.rb
+++ b/tasks/staticify.rb
@@ -17,7 +17,7 @@ module CRIU::Staticify
     version = CRIU::CRIU_VERSION
     tarball_url = "https://github.com/checkpoint-restore/criu/archive/v#{version}.tar.gz"
 
-    def criu_dir(b); "#{b.build_dir}/vendor/libcriu"; end
+    def criu_dir(b); (ENV["CRIU_TMP_DIR"] || "#{b.build_dir}/vendor/libcriu"); end
     def libcriu_dir(b); "#{criu_dir(b)}/lib/c"; end
     def libcriu_header(b); "#{criu_dir(b)}/lib/c/criu.h"; end
     def libcriu_a(b); libfile "#{criu_dir(b)}/lib/c/libcriu"; end
@@ -30,7 +30,7 @@ module CRIU::Staticify
       unless File.exist? libcriu_dir(build)
         tmpdir = '/tmp'
         run_command ENV, "rm -rf #{tmpdir}/libcriu-#{version}"
-        run_command ENV, "mkdir -p #{File.dirname(criu_dir(build))}"
+        run_command ENV, "mkdir -p #{File.dirname(criu_dir(build))} #{File.dirname(criu_dir(build))}"
         run_command ENV, "curl -sL #{tarball_url} | tar -xz -f - -C #{tmpdir}"
         run_command ENV, "mv -f #{tmpdir}/criu-#{version} #{criu_dir(build)}"
         run_command ENV, "cd #{criu_dir(build)} && patch -p1 < #{PATCH_PATH}"
@@ -41,7 +41,7 @@ module CRIU::Staticify
       unless File.exist?(libcriu_a(build))
         Dir.chdir criu_dir(build) do
           ENV["LD_FLAGS"] = "-lprotobuf-c"
-           run_command ENV, "make lib/c/libcriu.a"
+          run_command ENV, "make lib/c/libcriu.a"
         end
       end
     end


### PR DESCRIPTION
If we want to link libcriu to our app in static mode, write the line below:

```ruby
conf.cc.defines << "MRB_CRIU_USE_STATIC"
```

in `build_config.rb`.