### PR TITLE
Resolves `#include <criu/criu.h>` from checkout repositry for static build

### DIFF
--- a/tasks/staticify.rb
+++ b/tasks/staticify.rb
@@ -34,7 +34,7 @@ module CRIU::Staticify
         run_command ENV, "curl -sL #{tarball_url} | tar -xz -f - -C #{tmpdir}"
         run_command ENV, "mv -f #{tmpdir}/criu-#{version} #{criu_dir(build)}"
         run_command ENV, "cd #{criu_dir(build)} && patch -p1 < #{PATCH_PATH}"
-        run_command ENV, "cd #{File.dirname(libcriu_a(build))} && ln -s .. criu" # resolve include <criu/criu.h>
+        run_command ENV, "cd #{File.dirname(libcriu_a(build))} && ln -s . criu" # resolve include <criu/criu.h>
       end
     end
 

--- a/tasks/staticify.rb
+++ b/tasks/staticify.rb
@@ -34,6 +34,7 @@ module CRIU::Staticify
         run_command ENV, "curl -sL #{tarball_url} | tar -xz -f - -C #{tmpdir}"
         run_command ENV, "mv -f #{tmpdir}/criu-#{version} #{criu_dir(build)}"
         run_command ENV, "cd #{criu_dir(build)} && patch -p1 < #{PATCH_PATH}"
+        run_command ENV, "cd #{File.dirname(libcriu_a(build))} && ln -s .. criu" # resolve include <criu/criu.h>
       end
     end
 


### PR DESCRIPTION
Generally `criu` package places criu header into `$INCLUDE_DIR/criu/criu.h`. e.g. [Ubuntu Bionic](https://packages.ubuntu.com/ja/bionic/amd64/criu/filelist)

But criu repositry from git checkout places `criu.h` directory top of [`/lib/c/criu.h`](https://github.com/checkpoint-restore/criu/blob/criu-dev/lib/c/criu.h).

So I add a temporary symlink for resolving in both case of package or checkout.