### PR TITLE
Removing criu_set_service_comm()

### DIFF
--- a/src/mrb_criu.c
+++ b/src/mrb_criu.c
@@ -88,7 +88,6 @@ static mrb_value mrb_criu_init(mrb_state *mrb, mrb_value self)
   DATA_PTR(self) = data;
 
   criu_init_opts();
-  criu_set_service_comm(CRIU_COMM_SK);
 
   return self;
 }
@@ -292,9 +291,6 @@ static mrb_value mrb_criu_set_service_binary(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "z", &bin);
   criu_set_service_binary(bin);
-
-  /* Force to be comm_bin mode */
-  criu_set_service_comm(CRIU_COMM_BIN);
 
   return mrb_str_new_cstr(mrb, bin);
 }


### PR DESCRIPTION
Use CRIU 3.12 and trying to build, I get the following error:

```
/home/mrtc0/go/src/github.com/matsumotory/mruby-criu/src/mrb_criu.c:91:3: error: implicit declaration of function 'criu_set_service_comm' is
      invalid in C99 [-Werror,-Wimplicit-function-declaration]
  criu_set_service_comm(CRIU_COMM_SK);
  ^
/home/mrtc0/go/src/github.com/matsumotory/mruby-criu/src/mrb_criu.c:91:3: note: did you mean 'criu_set_service_fd'?
/usr/include/criu/criu.h:45:6: note: 'criu_set_service_fd' declared here
void criu_set_service_fd(int fd);
     ^
/home/mrtc0/go/src/github.com/matsumotory/mruby-criu/src/mrb_criu.c:297:3: error: implicit declaration of function 'criu_set_service_comm' is
      invalid in C99 [-Werror,-Wimplicit-function-declaration]
  criu_set_service_comm(CRIU_COMM_BIN);
  ^
2 errors generated.
/home/mrtc0/go/src/github.com/matsumotory/mruby-criu/src/mrb_criu.c:91:3: error: implicit declaration of function 'criu_set_service_comm' is
      invalid in C99 [-Werror,-Wimplicit-function-declaration]
  criu_set_service_comm(CRIU_COMM_SK);
  ^
/home/mrtc0/go/src/github.com/matsumotory/mruby-criu/src/mrb_criu.c:91:3: note: did you mean 'criu_set_service_fd'?
/usr/include/criu/criu.h:45:6: note: 'criu_set_service_fd' declared here
void criu_set_service_fd(int fd);
     ^
/home/mrtc0/go/src/github.com/matsumotory/mruby-criu/src/mrb_criu.c:297:3: error: implicit declaration of function 'criu_set_service_comm' is
      invalid in C99 [-Werror,-Wimplicit-function-declaration]
  criu_set_service_comm(CRIU_COMM_BIN);
  ^
2 errors generated.
```

In 3.12 set_service_comm is removed, so it can not compiled...

- https://github.com/checkpoint-restore/criu/commit/9ede9253f5d04e7ade626ece8b96bb66bf6dc938

#### Environment

```bash
$ mruby --version
mruby 2.0.1 (2019-04-04)
$ criu -V
Version: 3.12
```