### PR TITLE
Upgrade libcriu to v3.13

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -6,4 +6,5 @@ MRuby::Build.new do |conf|
 
   conf.gembox 'default'
   conf.gem '../mruby-criu'
+  conf.cc.defines << "MRB_CRIU_USE_STATIC"
 end

--- a/.travis_build_config.rb.lock
+++ b/.travis_build_config.rb.lock
@@ -1,0 +1,5 @@
+---
+mruby_version:
+  version: 2.1.0
+  release_no: 20100
+  git_commit: 57a56ddaa26d1bb7d67c8dde435b2e08dc17290f

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,6 +1,6 @@
 module CRIU
   unless CRIU.const_defined? :CRIU_VERSION
-    CRIU_VERSION = "3.10"
+    CRIU_VERSION = "3.13"
   end
 end
 

--- a/src/mrb_criu.c
+++ b/src/mrb_criu.c
@@ -6,6 +6,8 @@
 ** See Copyright Notice in LICENSE
 */
 
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -88,7 +90,6 @@ static mrb_value mrb_criu_init(mrb_state *mrb, mrb_value self)
   DATA_PTR(self) = data;
 
   criu_init_opts();
-  criu_set_service_comm(CRIU_COMM_SK);
 
   return self;
 }
@@ -292,9 +293,6 @@ static mrb_value mrb_criu_set_service_binary(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "z", &bin);
   criu_set_service_binary(bin);
-
-  /* Force to be comm_bin mode */
-  criu_set_service_comm(CRIU_COMM_BIN);
 
   return mrb_str_new_cstr(mrb, bin);
 }

--- a/tasks/staticify.rb
+++ b/tasks/staticify.rb
@@ -45,6 +45,7 @@ module CRIU::Staticify
         Dir.chdir criu_dir(build) do
           ENV["LD_FLAGS"] = "-lprotobuf-c"
           run_command ENV, "make lib/c/libcriu.a"
+          run_command ENV, "cp criu/include/version.h #{File.dirname(libcriu_a(build))}"
         end
       end
     end

--- a/tasks/staticify.rb
+++ b/tasks/staticify.rb
@@ -33,7 +33,9 @@ module CRIU::Staticify
         run_command ENV, "mkdir -p #{File.dirname(criu_dir(build))} #{File.dirname(criu_dir(build))}"
         run_command ENV, "curl -sL #{tarball_url} | tar -xz -f - -C #{tmpdir}"
         run_command ENV, "mv -f #{tmpdir}/criu-#{version} #{criu_dir(build)}"
-        run_command ENV, "cd #{criu_dir(build)} && patch -p1 < #{PATCH_PATH}"
+        if CRIU::CRIU_VERSION != '3.13'
+          run_command ENV, "cd #{criu_dir(build)} && patch -p1 < #{PATCH_PATH}"
+        end
         run_command ENV, "cd #{File.dirname(libcriu_a(build))} && ln -s . criu" # resolve include <criu/criu.h>
       end
     end


### PR DESCRIPTION
v3.13 has some changes:

* No need to patch to make `libcriu.a`. ref: https://github.com/checkpoint-restore/criu/pull/638
* `criu_set_service_comm` is deprecated and service_comm's are automatically set

And use mruby 2.1.0 by default for CI!